### PR TITLE
Fix Chrome MV3 blocking, add proxy detection, switch to per-site permissions

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,9 +4,14 @@
 let blocklist = [];
 let tabs = {};
 
-// Detect if the extension is running in Firefox
+// Detect if the extension is running in Firefox.
+// Chrome (MV3) exposes `chrome.declarativeNetRequest` but no blocking
+// `chrome.webRequest`. Recent Chrome versions also expose a `browser` global,
+// so we can't rely on that. Feature-detect the APIs we actually need instead.
 const IS_FIREFOX =
-  typeof browser !== "undefined" && typeof browser.runtime !== "undefined";
+  typeof chrome.declarativeNetRequest === "undefined" &&
+  typeof chrome.webRequest !== "undefined" &&
+  typeof chrome.webRequest.onBeforeRequest !== "undefined";
 const DEBUG = false;
 
 const debug = (...messages) => {
@@ -214,6 +219,13 @@ function updateListeners(blocklistLocal) {
 
   if (IS_FIREFOX) {
     // Firefox: Use webRequest API
+    if (!chrome.webRequest || !chrome.webRequest.onBeforeRequest) {
+      console.warn(
+        "chrome.webRequest.onBeforeRequest is not available; skipping listener update."
+      );
+      return;
+    }
+
     const urls = blocklist.reduce((list, { enabled, scripts = [] }) => {
       if (!enabled) return list;
       const add = scripts


### PR DESCRIPTION
## Summary

Closes https://github.com/simpleanalytics/extension/issues/5

- **Fixes Chrome breakage.** `IS_FIREFOX` detection no longer trips on Chrome's new `browser` global; Chrome stays on the `declarativeNetRequest` path.

The rest is in https://github.com/simpleanalytics/extension/pull/7

## Security implications

- [x] No security impact
- [ ] Has security impact - described as:

## Testing

Locally in Google Chrome.

### Test plan

- [x] Standard SA site: Block → allow → reload → icon gray, SA script blocked.
- [x] Proxy site: Block → allow → reload → `*/simple.gif` + detected proxy `.js` blocked.
- [x] Upgrade from 1.8 with existing sites: options page opens, Re-enable per site restores blocking.
- [x] Popup "the options page" link opens options and closes popup.

## Checklist

- [x] Linked to an issue
- [x] Tested
- [x] Asked for a review
